### PR TITLE
chore(ci): use Ubuntu 26.04 as the GitHub Actions runner image

### DIFF
--- a/.github/workflows/_checks.yaml
+++ b/.github/workflows/_checks.yaml
@@ -13,13 +13,13 @@ on:
 
 jobs:
   pre_commit:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/prek
 
   generate-nox-py-versions:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       py_version: ${{ steps.set-matrix.outputs.py_version }}
     steps:
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         py_version: ${{ fromJson(needs.generate-nox-py-versions.outputs.py_version) }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v9.0.0

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - id: release
         uses: googleapis/release-please-action@v5

--- a/prek.toml
+++ b/prek.toml
@@ -59,8 +59,8 @@ hooks = [
 ]
 
 [[repos]]
-repo = "https://github.com/rhysd/actionlint"
-rev = "v1.7.12"
+repo = "https://github.com/kjanat/actionlint"
+rev = "v1.10.0"
 hooks = [
     { id = "actionlint" },
 ]

--- a/template/prek.toml.jinja
+++ b/template/prek.toml.jinja
@@ -58,3 +58,10 @@ hooks = [
 repo = "https://github.com/pre-commit/mirrors-mypy"
 rev = "v2.3.0"
 hooks = [{ id = "mypy", exclude = { glob = [".pdbrc"] } }]
+
+[[repos]]
+repo = "https://github.com/rhysd/actionlint"
+rev = "v1.7.12"
+hooks = [
+    { id = "actionlint" },
+]

--- a/template/prek.toml.jinja
+++ b/template/prek.toml.jinja
@@ -60,8 +60,8 @@ rev = "v2.3.0"
 hooks = [{ id = "mypy", exclude = { glob = [".pdbrc"] } }]
 
 [[repos]]
-repo = "https://github.com/rhysd/actionlint"
-rev = "v1.7.12"
+repo = "https://github.com/kjanat/actionlint"
+rev = "v1.10.0"
 hooks = [
     { id = "actionlint" },
 ]

--- a/template/{%if is_github_project%}.github{%endif%}/workflows/_checks.yaml
+++ b/template/{%if is_github_project%}.github{%endif%}/workflows/_checks.yaml
@@ -13,13 +13,13 @@ on:
 
 jobs:
   pre_commit:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/prek
 
   generate-nox-sessions:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       session: ${{ steps.set-matrix.outputs.session }}
     steps:
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         session: ${{ fromJson(needs.generate-nox-sessions.outputs.session) }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v9.0.0

--- a/template/{%if is_github_project%}.github{%endif%}/workflows/ci.yaml
+++ b/template/{%if is_github_project%}.github{%endif%}/workflows/ci.yaml
@@ -14,4 +14,4 @@ jobs:
     # Guard against running this job if the Pull Request was closed without merging.
     # Also, this job is redundant if pipeline was triggered by merge of a 'Release Please' PR.
     if: ${{ github.event.pull_request.merged && github.head_ref != 'release-please--branches--main' }}
-    uses: ./.github/workflows/_pre-build-checks.yaml
+    uses: ./.github/workflows/_checks.yaml


### PR DESCRIPTION
Do not merge until:
- Ubuntu 26.04 runner images are out of 'public preview' and move to general availability (tracked in https://github.com/actions/runner-images/issues/14226)
- `rhysd/actionlint` is updated to recognise `ubuntu-26.04`: https://github.com/rhysd/actionlint/issues/682